### PR TITLE
Pass the TLS options to redirected requests correctly.

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -436,13 +436,13 @@ function XMLHttpRequest(opts) {
           };
 
           if (ssl) {
-            options.pfx = opts.pfx;
-            options.key = opts.key;
-            options.passphrase = opts.passphrase;
-            options.cert = opts.cert;
-            options.ca = opts.ca;
-            options.ciphers = opts.ciphers;
-            options.rejectUnauthorized = opts.rejectUnauthorized;
+            newOptions.pfx = opts.pfx;
+            newOptions.key = opts.key;
+            newOptions.passphrase = opts.passphrase;
+            newOptions.cert = opts.cert;
+            newOptions.ca = opts.ca;
+            newOptions.ciphers = opts.ciphers;
+            newOptions.rejectUnauthorized = opts.rejectUnauthorized;
           }
 
           // Issue the new request


### PR DESCRIPTION
The redirected request is given the `newOptions` object instead of the `options` used for the initial request.
