### PR TITLE
Use response.setEncoding() only if the function exists in response

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -454,7 +454,9 @@ function XMLHttpRequest(opts) {
           return;
         }
 
-        response.setEncoding("utf8");
+        if (response && response.setEncoding) {
+          response.setEncoding("utf8");
+        }
 
         setState(self.HEADERS_RECEIVED);
         self.status = response.statusCode;


### PR DESCRIPTION
With NodeJS 6 + Angular 2 + Socket.io, there's a case that response doesn't have setEncoding function set. To fix that just add simple check if response exists with the setEncoding property.

The problem can be tested with this app (by removing the hotfixes):
https://github.com/jussikinnula/angular2-socketio-chat-example
