### PR TITLE
Fix critical issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 Fork of [node-XMLHttpRequest](https://github.com/driverdan/node-XMLHttpRequest) by [driverdan](http://driverdan.com). Forked and published to npm because a [pull request](https://github.com/rase-/node-XMLHttpRequest/commit/a6b6f296e0a8278165c2d0270d9840b54d5eeadd) is not being created and merged. Changes made by [rase-](https://github.com/rase-/node-XMLHttpRequest/tree/add/ssl-support) are needed for [engine.io-client](https://github.com/Automattic/engine.io-client).
 
+## Usage ## 
+
+Here's how to include the module in your project and use as the browser-based
+XHR object.
+
+	var XMLHttpRequest = require("xmlhttprequest-ssl").XMLHttpRequest;
+	var xhr = new XMLHttpRequest();
+
+Note: use the lowercase string "xmlhttprequest-ssl" in your require(). On
+case-sensitive systems (eg Linux) using uppercase letters won't work.
 # Original README #
-
-node-XMLHttpRequest is a wrapper for the built-in http client to emulate the
-browser XMLHttpRequest object.
-
-This can be used with JS designed for browsers to improve reuse of code and
-allow the use of existing libraries.
-
-Note: This library currently conforms to [XMLHttpRequest 1](http://www.w3.org/TR/XMLHttpRequest/). Version 2.0 will target [XMLHttpRequest Level 2](http://www.w3.org/TR/XMLHttpRequest2/).
 
 ## Usage ##
 

--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -61,7 +61,7 @@ function XMLHttpRequest(opts) {
     "Accept": "*/*"
   };
 
-  var headers = defaultHeaders;
+  var headers = Object.assign({}, defaultHeaders);
 
   // These headers are not user setable.
   // The following are allowed but banned in the spec:
@@ -474,9 +474,11 @@ function XMLHttpRequest(opts) {
 
         response.on('end', function() {
           if (sendFlag) {
+            // The sendFlag needs to be set before setState is called.  Otherwise if we are chaining callbacks
+            // there can be a timing issue (the callback is called and a new call is made before the flag is reset).
+            sendFlag = false;
             // Discard the 'end' event if the connection has been aborted
             setState(self.DONE);
-            sendFlag = false;
           }
         });
 
@@ -574,7 +576,7 @@ function XMLHttpRequest(opts) {
       request = null;
     }
 
-    headers = defaultHeaders;
+    headers = Object.assign({}, defaultHeaders);
     this.responseText = "";
     this.responseXML = "";
 


### PR DESCRIPTION
- headers were not being reset for new requests.  This was resulting in header data from prior requests being used in new requests.  
- In response.on('end') the sendFlag was being reset after the setState call.  This was resulting in a timing issue when chaining callbacks which resulted in the second call failing due to an INVALID_STATE_ERR.
- Updated readme to reflect correct library name for import.