### PR TITLE
Null ops

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -37,6 +37,8 @@ XMLHttpRequest.XMLHttpRequest = XMLHttpRequest;
 function XMLHttpRequest(opts) {
   "use strict";
 
+  opts = opts || {};
+
   /**
    * Private variables
    */
@@ -378,10 +380,7 @@ function XMLHttpRequest(opts) {
       headers["Content-Length"] = 0;
     }
 
-    var agent = false;
-    if (opts && opts.agent) {
-      agent = opts.agent;
-    }
+    var agent = opts.agent || false;
     var options = {
       host: host,
       port: port,


### PR DESCRIPTION
ops can be null, there are places in the code that check for null o, and other places where a check is not made.  This commit sets the opts to an empty object if opts is null/undefined.  