### PR TITLE
Add readyState to static constants values

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -21,6 +21,16 @@ var spawn = require('child_process').spawn;
 
 module.exports = XMLHttpRequest;
 
+/**
+ * Static Constants
+ */
+
+XMLHttpRequest.UNSENT = XMLHttpRequest.UNSENT || 0;
+XMLHttpRequest.OPENED = XMLHttpRequest.OPENED || 1;
+XMLHttpRequest.HEADERS_RECEIVED = XMLHttpRequest.HEADERS_RECEIVED || 2;
+XMLHttpRequest.LOADING = XMLHttpRequest.LOADING || 3;
+XMLHttpRequest.DONE = XMLHttpRequest.DONE || 4;
+
 // backwards-compat
 XMLHttpRequest.XMLHttpRequest = XMLHttpRequest;
 
@@ -111,11 +121,11 @@ function XMLHttpRequest(opts) {
    * Constants
    */
 
-  this.UNSENT = 0;
-  this.OPENED = 1;
-  this.HEADERS_RECEIVED = 2;
-  this.LOADING = 3;
-  this.DONE = 4;
+  this.UNSENT = XMLHttpRequest.UNSENT;
+  this.OPENED = XMLHttpRequest.OPENED;
+  this.HEADERS_RECEIVED = XMLHttpRequest.HEADERS_RECEIVED;
+  this.LOADING = XMLHttpRequest.LOADING;
+  this.DONE = XMLHttpRequest.DONE;
 
   /**
    * Public vars

--- a/tests/test-constants.js
+++ b/tests/test-constants.js
@@ -3,6 +3,13 @@ var sys = require("util")
   , XMLHttpRequest = require("../lib/XMLHttpRequest").XMLHttpRequest
   , xhr = new XMLHttpRequest();
 
+// Test static constant values
+assert.equal(0, XMLHttpRequest.UNSENT);
+assert.equal(1, XMLHttpRequest.OPENED);
+assert.equal(2, XMLHttpRequest.HEADERS_RECEIVED);
+assert.equal(3, XMLHttpRequest.LOADING);
+assert.equal(4, XMLHttpRequest.DONE);
+
 // Test constant values
 assert.equal(0, xhr.UNSENT);
 assert.equal(1, xhr.OPENED);


### PR DESCRIPTION
In browser, built-in `XMLHttpRequest` has supported `readyState` as static constants values.
But here, not supported like this:
```javascript
const request = new XMLHttpRequest();
request.onreadystatechange = function(event) {
  if (request.readyState === XMLHttpRequest.DONE) {  // expected '4', but 'undefined' found
    ...
  }
}
```

Please refer to these links:
* https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
* https://xhr.spec.whatwg.org/#interface-xmlhttprequest