### PR TITLE
Expose error in status property when loading from local file system

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -324,7 +324,7 @@ function XMLHttpRequest(opts) {
       if (settings.async) {
         fs.readFile(unescape(url.pathname), 'utf8', function(error, data) {
           if (error) {
-            self.handleError(error);
+            self.handleError(error, error.errno || -1);
           } else {
             self.status = 200;
             self.responseText = data;
@@ -337,7 +337,7 @@ function XMLHttpRequest(opts) {
           this.status = 200;
           setState(self.DONE);
         } catch(e) {
-          this.handleError(e);
+          this.handleError(e, e.errno || -1);
         }
       }
 


### PR DESCRIPTION
When making a GET from the local file system an error will not be visible from the outside caller as the status property will be set to 0 which is the same as if the GET was successful.