### PR TITLE
fix: proper fetching of binary data during get requests

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -130,6 +130,7 @@ function XMLHttpRequest(opts) {
   // Result & response
   this.responseText = "";
   this.responseXML = "";
+  this.response = Buffer.alloc(0);
   this.status = null;
   this.statusText = null;
 
@@ -453,7 +454,7 @@ function XMLHttpRequest(opts) {
         }
 
         if (response && response.setEncoding) {
-          response.setEncoding("utf8");
+          response.setEncoding('binary');
         }
 
         setState(self.HEADERS_RECEIVED);
@@ -462,7 +463,9 @@ function XMLHttpRequest(opts) {
         response.on('data', function(chunk) {
           // Make sure there's some data
           if (chunk) {
-            self.responseText += chunk;
+            var data = Buffer.from(chunk, 'binary');
+            self.responseText += data.toString('utf8');
+            self.response = Buffer.concat([self.response, data]);
           }
           // Don't emit state changes if the connection has been aborted.
           if (sendFlag) {
@@ -517,13 +520,16 @@ function XMLHttpRequest(opts) {
         + "var doRequest = http" + (ssl ? "s" : "") + ".request;"
         + "var options = " + JSON.stringify(options) + ";"
         + "var responseText = '';"
+        + "var responseData = Buffer.alloc(0);"
         + "var req = doRequest(options, function(response) {"
-        + "response.setEncoding('utf8');"
+        + "response.setEncoding('binary');"
         + "response.on('data', function(chunk) {"
-        + "  responseText += chunk;"
+        + "  var data = Buffer.from(chunk, 'binary');"
+        + "  responseText += data.toString('utf8');"
+        + "  responseData = Buffer.concat([responseData, data]);"
         + "});"
         + "response.on('end', function() {"
-        + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-STATUS:' + response.statusCode + ',' + responseText, 'utf8');"
+        + "fs.writeFileSync('" + contentFile + "', JSON.stringify({err: null, data: {statusCode: response.statusCode, headers: response.headers, text: responseText, data: responseData.toString('base64')}}), 'utf8');"
         + "fs.unlinkSync('" + syncFile + "');"
         + "});"
         + "response.on('error', function(error) {"
@@ -555,6 +561,8 @@ function XMLHttpRequest(opts) {
         // If the file returned okay, parse its data and move to the DONE state
         self.status = self.responseText.replace(/^NODE-XMLHTTPREQUEST-STATUS:([0-9]*),.*/, "$1");
         self.responseText = self.responseText.replace(/^NODE-XMLHTTPREQUEST-STATUS:[0-9]*,(.*)/, "$1");
+        var resp = JSON.parse(self.responseText);
+        self.response = Buffer.from(resp.data.data, 'base64');
         setState(self.DONE);
       }
     }


### PR DESCRIPTION
This MR allows for synchronous and asynchronous GET requests that fetch binary data to be returned in a new field called `XMLHttpRequest.response` with the expected binary data. `XMLHttpRequest.responseText` is still text that is encoded in 'utf8' format.