### PR TITLE
Replace setImmediate with setTimeout 0

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -635,14 +635,14 @@ function XMLHttpRequest(opts) {
   this.dispatchEvent = function (event) {
     if (typeof self["on" + event] === "function") {
       if (this.readyState === this.DONE && settings.async)
-        setImmediate(function() { self["on" + event]() })
+        setTimeout(function() { self["on" + event]() }, 0)
       else
         self["on" + event]()
     }
     if (event in listeners) {
       for (let i = 0, len = listeners[event].length; i < len; i++) {
         if (this.readyState === this.DONE)
-          setImmediate(function() { listeners[event][i].call(self) })
+          setTimeout(function() { listeners[event][i].call(self) }, 0)
         else
           listeners[event][i].call(self)
       }


### PR DESCRIPTION
There are a few references to setImmediate, https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate which was only partially adopted by node, and breaks lots of jsdom things. 

I think it's usage leads to lots of downstream headaches for users of the lib. See the google results: https://www.google.com/search?q=jsdom++setImmediate+is+not+defined+site:github.com&client=firefox-b-1-d&sxsrf=AB5stBg2qBNE8pVK3DI98qSnmKt7yqTREg:1689006813782&sa=X&ved=2ahUKEwiGgKLZyISAAxVYie4BHdkhB4IQrQIoBHoECBUQBQ&biw=1479&bih=1010&dpr=2#ip=1

This obviously isn't the only lib that uses setImmediate, but it's a big one that I've had to work around on a few projects now. 

This PR replaces the use of setImmediate with setTimeout(() => {...}, 0), which is functionally very similar. https://nodejs.dev/en/learn/understanding-setimmediate/

For the purposes of this library, I don't see any reason to use setImmediate over setTimeout. 