### PR TITLE
Implement a portion of responseType 

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -127,8 +127,16 @@ function XMLHttpRequest(opts) {
   // default ready state change handler in case one is not set or is set late
   this.onreadystatechange = null;
 
+  var responseType = "";
   // Result & response
-  this.responseType = ""; /* 'arraybuffer' or 'text' or '' */
+  Object.defineProperty(this, "responseType", {
+    get() { return responseType; },
+    set(newValue) {
+      if (this.readyState === this.LOADING || this.readyState === this.DONE)
+        throw new Error("InvalidState: cannot change responseType while in loading or done");
+      responseType = newValue;
+    },
+  });
   this.responseText = "";
   this.responseXML = "";
   this.response = Buffer.alloc(0);
@@ -458,13 +466,18 @@ function XMLHttpRequest(opts) {
 
         setState(self.HEADERS_RECEIVED);
 
+        var receivedData;
         // When responseType is 'text' (or ''), response will be utf8 decoded text.
         // cf. 3.6.9.1 of https://xhr.spec.whatwg.org/#the-response-attribute
         if (self.responseType === '' || self.responseType === 'text') {
-          if (response.setEncoding) {
+          if (response.setEncoding)
             response.setEncoding("utf8");
-            self.response = '';
-          }
+          self.response = '';
+          receivedData = '';
+        }
+        else {
+          self.response = null;
+          receivedData = Buffer.alloc(0);
         }
 
         self.status = response.statusCode;
@@ -474,11 +487,11 @@ function XMLHttpRequest(opts) {
           if (chunk) {
             if (self.responseType === '' || self.responseType === 'text') {
               // When responseType is 'text' (or ''), then each chunk is already utf8 decoded.
-              self.response += chunk;
+              receivedData += chunk;
             } else {
               // Otherwise get the raw bytes.
               var data = Buffer.from(chunk);
-              self.response = Buffer.concat([self.response, data]);
+              receivedData = Buffer.concat([receivedData, data]);
             }
           }
           // Don't emit state changes if the connection has been aborted.
@@ -494,6 +507,7 @@ function XMLHttpRequest(opts) {
             sendFlag = false;
             // Discard the 'end' event if the connection has been aborted
             setState(self.DONE);
+            self.response = receivedData;
             // Get responseText from response.
             if (self.responseType === '' || self.responseType === 'text') {
               // Reponse is already decoded utf8.

--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -128,6 +128,7 @@ function XMLHttpRequest(opts) {
   this.onreadystatechange = null;
 
   // Result & response
+  this.responseType = ""; /* 'arraybuffer' or 'text' or '' */
   this.responseText = "";
   this.responseXML = "";
   this.response = Buffer.alloc(0);
@@ -456,13 +457,29 @@ function XMLHttpRequest(opts) {
         }
 
         setState(self.HEADERS_RECEIVED);
+
+        // When responseType is 'text' (or ''), response will be utf8 decoded text.
+        // cf. 3.6.9.1 of https://xhr.spec.whatwg.org/#the-response-attribute
+        if (self.responseType === '' || self.responseType === 'text') {
+          if (response.setEncoding) {
+            response.setEncoding("utf8");
+            self.response = '';
+          }
+        }
+
         self.status = response.statusCode;
 
         response.on('data', function(chunk) {
           // Make sure there's some data
           if (chunk) {
-            var data = Buffer.from(chunk);
-            self.response = Buffer.concat([self.response, data]);
+            if (self.responseType === '' || self.responseType === 'text') {
+              // When responseType is 'text' (or ''), then each chunk is already utf8 decoded.
+              self.response += chunk;
+            } else {
+              // Otherwise get the raw bytes.
+              var data = Buffer.from(chunk);
+              self.response = Buffer.concat([self.response, data]);
+            }
           }
           // Don't emit state changes if the connection has been aborted.
           if (sendFlag) {
@@ -477,8 +494,11 @@ function XMLHttpRequest(opts) {
             sendFlag = false;
             // Discard the 'end' event if the connection has been aborted
             setState(self.DONE);
-            // Construct responseText from response
-            self.responseText = self.response.toString('utf8');
+            // Get responseText from response.
+            if (self.responseType === '' || self.responseType === 'text') {
+              // Reponse is already decoded utf8.
+              self.responseText = self.response;
+	    }
           }
         });
 

--- a/tests/test-utf8-tearing.js
+++ b/tests/test-utf8-tearing.js
@@ -179,6 +179,10 @@ const urlUtf8 = "http://localhost:8888/binaryUtf8";
 function Get(url, isUtf8) {
   return new Promise((resolve, reject) => {
     xhr.open("GET", url, true);
+    if (isUtf8)
+      xhr.responseType = 'text';
+    else
+      xhr.responseType = 'arraybuffer';
     xhr.onloadend = function(event) {
 
       log('xhr.status:', xhr.status);
@@ -189,7 +193,7 @@ function Get(url, isUtf8) {
 
         const dataTxt = xhr.responseText;
         const data = xhr.response;
-        assert(dataTxt && data);
+        assert(data);
 
         log('XHR GET:', contentType, dataTxt.length, data.length, data.toString('utf8').length);
         log('XHR GET:', data.constructor.name, dataTxt.constructor.name);


### PR DESCRIPTION
Implements https://xhr.spec.whatwg.org/#the-responsetype-attribute, up to the responseTypes of '', 'text', and 'arraybuffer'.

Includes some changes to response to use the new responseType, as well as better conformance for when values become available (only once the state is done does response become available, not being updated as each data segment arrives)