### PR TITLE
Case-insensitive check for content type before setting it

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -374,7 +374,8 @@ function XMLHttpRequest(opts) {
     } else if (data) {
       headers["Content-Length"] = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
 
-      if (!headers["Content-Type"]) {
+      var headersKeys = Object.keys(headers);
+      if (!headersKeys.some(h => /content-type/i.test(h))) {
         headers["Content-Type"] = "text/plain;charset=UTF-8";
       }
     } else if (settings.method === "POST") {

--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -375,7 +375,7 @@ function XMLHttpRequest(opts) {
       headers["Content-Length"] = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
 
       var headersKeys = Object.keys(headers);
-      if (!headersKeys.some(h => /content-type/i.test(h))) {
+      if (!headersKeys.some(function (h) { return h.toLowerCase() === 'content-type' })) {
         headers["Content-Type"] = "text/plain;charset=UTF-8";
       }
     } else if (settings.method === "POST") {

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -12,6 +12,8 @@ var server = http.createServer(function (req, res) {
   assert.equal("node-XMLHttpRequest-test", req.headers["user-agent"]);
   // Test header set with blacklist disabled
   assert.equal("http://github.com", req.headers["referer"]);
+  // Test case insensitive header was set
+  assert.equal("text/plain", req.headers["content-type"]);
 
   var body = "Hello World";
   res.writeHead(200, {
@@ -53,13 +55,16 @@ xhr.onreadystatechange = function() {
 
 assert.equal(null, xhr.getResponseHeader("Content-Type"));
 try {
-  xhr.open("GET", "http://localhost:8000/");
+  xhr.open("POST", "http://localhost:8000/");
+  var body = "Hello World";
   // Valid header
   xhr.setRequestHeader("X-Test", "Foobar");
   // Invalid header
-  xhr.setRequestHeader("Content-Length", 0);
+  xhr.setRequestHeader("Content-Length", Buffer.byteLength(body));
   // Allowed header outside of specs
   xhr.setRequestHeader("user-agent", "node-XMLHttpRequest-test");
+  // Case insensitive header
+  xhr.setRequestHeader("content-type", 'text/plain');
   // Test getRequestHeader
   assert.equal("Foobar", xhr.getRequestHeader("X-Test"));
   // Test invalid header
@@ -70,7 +75,7 @@ try {
   xhr.setRequestHeader("Referer", "http://github.com");
   assert.equal("http://github.com", xhr.getRequestHeader("Referer"));
 
-  xhr.send();
+  xhr.send(body);
 } catch(e) {
   console.log("ERROR: Exception raised", e);
 }


### PR DESCRIPTION
Updated `tests/test-headers.js` to test for the case this PR addresses.

If the following conditions were met it would result in the content-type header always being "text/plain;charset=UTF-8":
- The method is not GET or HEAD
- Data is being sent
- When setting the content-type header, the key used is anything other than a case-sensitive "Content-Type"

I encountered it when sending a POST request with `xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');`, then was surprised by the server receiving the content-type as `text/plain`.
